### PR TITLE
Fix WebP animation speed bug

### DIFF
--- a/src/ImageSharp/Formats/Webp/WebpFrameMetadata.cs
+++ b/src/ImageSharp/Formats/Webp/WebpFrameMetadata.cs
@@ -48,7 +48,7 @@ public class WebpFrameMetadata : IDeepCloneable
     internal static WebpFrameMetadata FromAnimatedMetadata(AnimatedImageFrameMetadata metadata)
         => new()
         {
-            FrameDelay = (uint)metadata.Duration.Milliseconds,
+            FrameDelay = (uint)metadata.Duration.TotalMilliseconds,
             BlendMethod = metadata.BlendMode == FrameBlendMode.Source ? WebpBlendMethod.Source : WebpBlendMethod.Over,
             DisposalMethod = metadata.DisposalMode == FrameDisposalMode.RestoreToBackground ? WebpDisposalMethod.RestoreToBackground : WebpDisposalMethod.DoNotDispose
         };


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
`Milliseconds` is the milli seconds component of the TimeSpan, `TotalMilliseconds` is the entire TimeSpan expressed as milliseconds.

Example, Timespan of 3.5 seconds:
* `Milliseconds`: 500
* `TotalMilliseconds`: 3500

Fixes #2619